### PR TITLE
 Support resque-scheduler's delayed? method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source :rubygems
 
 gemspec
+
+gem 'rspec', '~> 2.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,14 @@
 PATH
   remote: .
   specs:
-    resque_spec (0.12.6)
+    resque_spec (0.12.7)
       resque (>= 1.19.0)
       rspec (>= 2.5.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
-    columnize (0.3.6)
     diff-lcs (1.1.3)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     multi_json (1.3.5)
     rack (1.4.1)
     rack-protection (1.2.0)
@@ -38,16 +34,6 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     rufus-scheduler (2.0.16)
       tzinfo (>= 0.3.23)
     sinatra (1.3.2)
@@ -67,5 +53,8 @@ DEPENDENCIES
   rake
   resque-scheduler
   resque_spec!
-  ruby-debug19
+  rspec (~> 2.10.0)
   timecop
+
+BUNDLED WITH
+   1.16.6

--- a/lib/resque_spec/matchers.rb
+++ b/lib/resque_spec/matchers.rb
@@ -109,7 +109,7 @@ module ScheduleQueueHelper
     klass.instance_eval do
       self.queue_name = nil
       chain :queue do |queue_name|
-        self.queue_name = queue_name
+        self.queue_name = ResqueSpec.schedule_queue_name_for_queue_name(queue_name)
       end
     end
   end

--- a/lib/resque_spec/scheduler.rb
+++ b/lib/resque_spec/scheduler.rb
@@ -39,6 +39,12 @@ module ResqueSpec
       ResqueSpec.enqueue_in_with_queue(queue, time, klass, *args)
     end
 
+    def delayed?(klass, *args)
+      return delayed_without_resque_spec(klass, *args) if ResqueSpec.disable_ext && respond_to?(:delayed_without_resque_spec)
+
+      ResqueSpec.delayed?(klass, *args)
+    end
+
     def remove_delayed(klass, *args)
       return remove_delayed_without_resque_spec(klass, *args) if ResqueSpec.disable_ext && respond_to?(:remove_delayed_without_resque_spec)
 
@@ -61,6 +67,13 @@ module ResqueSpec
 
   def enqueue_in_with_queue(queue, time, klass, *args)
     enqueue_at_with_queue(queue, Time.now + time, klass, *args)
+  end
+
+  def delayed?(klass, *args)
+    sched_queue = queue_by_name(schedule_queue_name(klass))
+    sched_queue.any? do |job|
+      job[:class] == klass.to_s && job[:args] == args
+    end
   end
 
   def remove_delayed(klass, *args)

--- a/lib/resque_spec/scheduler.rb
+++ b/lib/resque_spec/scheduler.rb
@@ -47,12 +47,12 @@ module ResqueSpec
   end
 
   def enqueue_at(time, klass, *args)
-    enqueue_at_with_queue(schedule_queue_name(klass), time, klass, *args)
+    enqueue_at_with_queue(queue_name(klass), time, klass, *args)
   end
 
   def enqueue_at_with_queue(queue, time, klass, *args)
     is_time?(time)
-    perform_or_store(queue, :class => klass.to_s, :time  => time, :stored_at => Time.now, :args => args)
+    perform_or_store(schedule_queue_name_for_queue_name(queue), :class => klass.to_s, :time  => time, :stored_at => Time.now, :args => args)
   end
 
   def enqueue_in(time, klass, *args)
@@ -77,6 +77,10 @@ module ResqueSpec
     queue_by_name(schedule_queue_name(klass))
   end
 
+  def schedule_queue_name_for_queue_name(queue_name)
+    "#{queue_name}_scheduled"
+  end
+
   private
 
   def is_time?(time)
@@ -84,7 +88,7 @@ module ResqueSpec
   end
 
   def schedule_queue_name(klass)
-    "#{queue_name(klass)}_scheduled"
+    schedule_queue_name_for_queue_name(queue_name(klass))
   end
 end
 

--- a/resque_spec.gemspec
+++ b/resque_spec.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('resque', ['>= 1.19.0'])
   s.add_runtime_dependency('rspec', ['>= 2.5.0'])
   s.add_development_dependency('resque-scheduler')
-  s.add_development_dependency('ruby-debug19')
   s.add_development_dependency('timecop')
   s.add_development_dependency('rake')
 end

--- a/spec/resque_spec/scheduler_spec.rb
+++ b/spec/resque_spec/scheduler_spec.rb
@@ -116,19 +116,19 @@ describe ResqueSpec do
       end
 
       it "adds to the scheduled queue hash" do
-        ResqueSpec.queue_by_name(:test_queue).should_not be_empty
+        ResqueSpec.queue_by_name(:test_queue_scheduled).should_not be_empty
       end
 
       it "sets the klass on the queue" do
-        ResqueSpec.queue_by_name(:test_queue).first.should include(:class => NoQueueClass.to_s)
+        ResqueSpec.queue_by_name(:test_queue_scheduled).first.should include(:class => NoQueueClass.to_s)
       end
 
       it "sets the arguments on the queue" do
-        ResqueSpec.queue_by_name(:test_queue).first.should include(:time => scheduled_at)
+        ResqueSpec.queue_by_name(:test_queue_scheduled).first.should include(:time => scheduled_at)
       end
       
       it "uses the correct queue" do 
-        ResqueSpec.queue_by_name(:test_queue).should_not be_empty
+        ResqueSpec.queue_by_name(:test_queue_scheduled).should_not be_empty
       end
     end
     
@@ -143,19 +143,19 @@ describe ResqueSpec do
       end
 
       it "adds to the scheduled queue hash" do
-        ResqueSpec.queue_by_name(:test_queue).should_not be_empty
+        ResqueSpec.queue_by_name(:test_queue_scheduled).should_not be_empty
       end
 
       it "sets the klass on the queue" do
-        ResqueSpec.queue_by_name(:test_queue).first.should include(:class => NoQueueClass.to_s)
+        ResqueSpec.queue_by_name(:test_queue_scheduled).first.should include(:class => NoQueueClass.to_s)
       end
 
       it "sets the arguments on the queue" do
-        ResqueSpec.queue_by_name(:test_queue).first.should include(:time => Time.now + scheduled_in)
+        ResqueSpec.queue_by_name(:test_queue_scheduled).first.should include(:time => Time.now + scheduled_in)
       end
       
       it "uses the correct queue" do 
-        ResqueSpec.queue_by_name(:test_queue).should_not be_empty
+        ResqueSpec.queue_by_name(:test_queue_scheduled).should_not be_empty
       end
     end
 

--- a/spec/resque_spec/scheduler_spec.rb
+++ b/spec/resque_spec/scheduler_spec.rb
@@ -159,6 +159,33 @@ describe ResqueSpec do
       end
     end
 
+    describe "#delayed?" do
+      let(:job_class) { NameFromClassMethod }
+      let(:args) { [1] }
+
+      describe "when the job has not been scheduled" do
+        it "should return false" do
+          Resque.delayed?(job_class, *args).should be(false)
+        end
+      end
+
+      describe "when the job has been scheduled" do
+        before { Resque.enqueue_at(scheduled_at, job_class, *args) }
+
+        it "should return true" do
+          Resque.delayed?(job_class, *args).should be(true)
+        end
+      end
+
+      describe "when the job has been queued normally" do
+        before { Resque.enqueue(job_class, *args) }
+
+        it "should return false" do
+          Resque.delayed?(job_class, *args).should be(false)
+        end
+      end
+    end
+
     describe "#remove_delayed" do
       describe "with #enqueue_at" do
         before do


### PR DESCRIPTION
resque-scheduler uses `delayed?` to check for the presence of a
delayed job. Stub it out, so tests that use it don't fail.

This also includes the changes in #1. That one should be accepted first, then this one.